### PR TITLE
perf: remove query paramters from href before getting mime type

### DIFF
--- a/src/image-mime.test.ts
+++ b/src/image-mime.test.ts
@@ -18,6 +18,11 @@ test("getImageMimeType()", () => {
   expect(getImageMimeType(".gif")).toBe("image/gif");
   expect(getImageMimeType("vector.svg")).toBe("image/svg+xml");
   expect(getImageMimeType("/dense.png")).toBe("image/png");
+  expect(
+    getImageMimeType(
+      "https://techcrunch.com/wp-content/uploads/2020/10/Google-Workspace-Icons.png?w=680",
+    ),
+  ).toBe("image/png");
   expect(() => getImageMimeType("error.exe")).toThrow("convert");
 });
 

--- a/src/image-mime.ts
+++ b/src/image-mime.ts
@@ -18,13 +18,15 @@ export function isImageMimeType(str: string): str is ImageMime {
  * Throws an Error is if extension doesn't correspond to an {@link ImageMime}.
  */
 export function getImageMimeType(href: string): ImageMime {
-  if (href.endsWith(".png")) {
+  const src = href.split("?")[0];
+
+  if (src.endsWith(".png")) {
     return "image/png";
-  } else if (href.endsWith(".gif")) {
+  } else if (src.endsWith(".gif")) {
     return "image/gif";
-  } else if (href.endsWith(".svg")) {
+  } else if (src.endsWith(".svg")) {
     return "image/svg+xml";
-  } else if (href.endsWith(".jpg") || href.endsWith(".jpeg")) {
+  } else if (src.endsWith(".jpg") || src.endsWith(".jpeg")) {
     return "image/jpeg";
   } else {
     throw new Error(`can't convert '${href}' to a mime type`);

--- a/src/image-mime.ts
+++ b/src/image-mime.ts
@@ -18,7 +18,7 @@ export function isImageMimeType(str: string): str is ImageMime {
  * Throws an Error is if extension doesn't correspond to an {@link ImageMime}.
  */
 export function getImageMimeType(href: string): ImageMime {
-  const src = href.split("?")[0].toLowerCase();
+  const [src] = href.toLowerCase().split("?", 1);
 
   if (src.endsWith(".png")) {
     return "image/png";

--- a/src/image-mime.ts
+++ b/src/image-mime.ts
@@ -18,7 +18,7 @@ export function isImageMimeType(str: string): str is ImageMime {
  * Throws an Error is if extension doesn't correspond to an {@link ImageMime}.
  */
 export function getImageMimeType(href: string): ImageMime {
-  const src = href.split("?")[0];
+  const src = href.split("?")[0].toLowerCase();
 
   if (src.endsWith(".png")) {
     return "image/png";


### PR DESCRIPTION
In case of "can't convert 'https://techcrunch.com/wp-content/uploads/2020/10/Google-Workspace-Icons.png?w=680' to a mime type".